### PR TITLE
Fix #30 by adding a art walk participation option

### DIFF
--- a/app/views/camps/_form.html.erb
+++ b/app/views/camps/_form.html.erb
@@ -108,8 +108,14 @@
     <%= form.label t("form_dream_visability_yes") %>
     <%= form.radio_button :is_public, false %>
     <%= form.label t("form_dream_visability_no") %>
-    <br/>
+    <hr/>
     <%= t("form_dream_visability_guidetext_html") %>
+  </div>
+  <div class="combo" id="artwalk">
+    <h2><%= t("form_dream_artwalk_participation") %></h2>
+    <%= form.input :is_in_artwalk, as: :radio_buttons %>
+    <hr/>
+    <%= t("form_dream_artwalk_guidetext_html") %>
   </div>
   <div class="combo" id="contact_phone">
     <% if app_setting("contact_phone") %>

--- a/app/views/camps/show.html.erb
+++ b/app/views/camps/show.html.erb
@@ -63,7 +63,6 @@
                     </p>
                     <p class='dream_main_creator'><%= @camp.contact_name %></p>
 
-
                     <!-- Granting system -->
                     <% if app_setting("granting_active") and @camp.minbudget.present? and @camp.maxbudget.present? %>
 
@@ -377,6 +376,17 @@
             </div>
         </div> <!-- safety-file-comments -->
         <% end %>
+
+	<div class="panel panel-default">
+	  <div class="panel-heading">
+	    <h2 class="header-sub-heading">Additional info</h2>
+	  </div>
+	  <div class="panel-body">
+	    <% if @camp.is_in_artwalk %>
+		<span class="label label-info"><span class="glyphicon glyphicon-education vertical-middle" aria-hidden="true"></span> Part of artwalk</span>
+	    <% end %>
+  	  </div>
+	</div>
 
         <%= render 'tags' %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,6 +55,10 @@ en:
   form_dream_visability_yes: "Yes, show my ideas to the world!"
   form_dream_visability_no: "No, Hide it for now"
   form_dream_visability_guidetext_html: Public dreams will be shown on the main page. Private dreams will be shown only with a direct link
+  form_dream_artwalk_participation: "Will your dream participate in the artwalk?"
+  form_dream_artwalk_participation_yes: "Yes!"
+  form_dream_artwalk_participation_no: "No!"
+  form_dream_artwalk_guidetext_html: Every year a artwalk is organized where non members are invited to a guided walk of the Borderland. Add your dream to be part of the walk!
   form_contact_phone_label: Your phone number (won't be published)
   form_contact_phone_guidetext_html: Emergency contact
   form_about_the_artist_label: About the crew / artist

--- a/db/migrate/20200216202913_add_is_in_artwalk_to_camp.rb
+++ b/db/migrate/20200216202913_add_is_in_artwalk_to_camp.rb
@@ -1,0 +1,5 @@
+class AddIsInArtwalkToCamp < ActiveRecord::Migration[5.0]
+  def change
+    add_column :camps, :is_in_artwalk, :bool
+  end
+end


### PR DESCRIPTION
Could prolly have done with a tag too but this was maybe a bit cleaner. 

Now users will be asked in the dream creation or edit interface to let us know if they wanna art walk. Then it should be easy peasy to just pull alist of the walky dreams. It will also show up as a little badge in brand new "additional info" section of the dream pages. 