### PR TITLE
Fix #28 by adding support for linked talk accounts

### DIFF
--- a/app/views/camps/_crew.html.erb
+++ b/app/views/camps/_crew.html.erb
@@ -5,14 +5,28 @@
                 <%= simple_form_for @camp, url: { action: 'remove_member'} do |f| %>
                   <div id="crew-container" class="crew-container">
                       <div class="profile-pic">
+			<% if @camp.creator.avatar %>
+                          <%= link_to image_tag(@camp.creator.avatar, :class => "img-circle dreamcrew-photo"), @camp.creator %>
+			<% else %>
                           <%= link_to image_tag('crewpope.png', :class => "img-circle dreamcrew-photo"), @camp.creator %>
-                        <span class="tooltiptext"><b><%= @camp.creator.name %></b></span>
+			<% end %>
+                          <span class="tooltiptext">
+			    <p><b><%=t :user %>:</b> <%= @camp.creator.name ? @camp.creator.name : "-" %></p>
+			    <p><b><%=t :talk_user %>:</b> <%= @camp.creator.talk_username ? @camp.creator.talk_username : "-" %></p>
+			  </span>
                       </div>
                       <% @camp.memberships.each do |member| %>
                           <div class="profile-pic">
-                          <%= link_to image_tag('crew-default.png', :class => "img-circle dreamcrew-photo"), member.user %>
+			  <% if member.user.avatar %>
+			    <%= link_to image_tag(member.user.avatar, :class => "img-circle dreamcrew-photo"), member.user %>
+			  <% else %>
+			    <%= link_to image_tag('crew-default.png', :class => "img-circle dreamcrew-photo"), member.user %>
+			  <% end %>
                           <%= link_to '✘', remove_member_camp_path(@camp, member), class: 'edit', method: :post %>
-                          <span class="tooltiptext"><b><%= member.user.name or "" %></b></span>
+                          <span class="tooltiptext">
+			    <p><b><%=t :user %>:</b> <%= member.user.name? ? member.user.name : "-" %></p>
+			    <p><b><%=t :talk_user %>:</b> <%= member.user.talk_username? ? member.user.talk_username : "-" %></p>
+			  </span>
                         </div>
                       <% end %>
                     <% if current_user && (@camp.creator == current_user || current_user.is_crewmember(@camp)) %>

--- a/app/views/users/_your_space.html.erb
+++ b/app/views/users/_your_space.html.erb
@@ -6,6 +6,7 @@
     </div>
     <div class="panel-body">
       <p><b><%=t :contact_email %></b>: <%= current_user.email %></p>
+      <p><b><%=t :talk_username %></b>: <%= current_user.talk_username %></p>
 
       <% if current_user.created_camps.any? %>
         <p><b><%=t(:your_dream, count: current_user.created_camps.count) %></b>: </p>

--- a/db/migrate/20200328161945_add_talk_username_to_users.rb
+++ b/db/migrate/20200328161945_add_talk_username_to_users.rb
@@ -1,0 +1,6 @@
+class AddTalkUsernameToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :talk_username, :string
+    add_column :users, :talk_id, :integer
+  end
+end


### PR DESCRIPTION
Add support for linking talk accounts. Cant be done automagically afaik so admin will have to update the talk_id records in the db to start with. After that everytime the users log in the username, maybe name and avatar will be sucked in from talk.  